### PR TITLE
Compatibility Modifications for GCC 6.1 on Solus 1.2.1 

### DIFF
--- a/config/Makevars.mk
+++ b/config/Makevars.mk
@@ -60,7 +60,7 @@ endif
 # Also: We need pthread!
 COMMON_CFLAGS+=-Wall -pedantic -Wundef -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 # not reliable enough: COMMON_CPPFLAGS+=-Wmissing-noreturn -ansi -pedantic -Wall -Werror -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
-COMMON_CPPFLAGS+=-ansi -std=gnu++11 -pedantic -Wall -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
+COMMON_CPPFLAGS+=-ansi -pedantic -Wall -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 COMMON_LDFLAGS+=-Wl,--fatal-warnings -pthread
 
 # Ubuntu 12.04 needs this for clock_gettime

--- a/config/Makevars.mk
+++ b/config/Makevars.mk
@@ -58,9 +58,9 @@ endif
 
 # Common flags: All about errors -- let's help them help us
 # Also: We need pthread!
-COMMON_CFLAGS+=-Wall -pedantic -Werror -Wundef -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
+COMMON_CFLAGS+=-Wall -pedantic -Wundef -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 # not reliable enough: COMMON_CPPFLAGS+=-Wmissing-noreturn -ansi -pedantic -Wall -Werror -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
-COMMON_CPPFLAGS+=-ansi -pedantic -Wall -Werror -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
+COMMON_CPPFLAGS+=-ansi -std=gnu++11 -pedantic -Wall -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 COMMON_LDFLAGS+=-Wl,--fatal-warnings -pthread
 
 # Ubuntu 12.04 needs this for clock_gettime

--- a/config/Makevars.mk
+++ b/config/Makevars.mk
@@ -58,9 +58,9 @@ endif
 
 # Common flags: All about errors -- let's help them help us
 # Also: We need pthread!
-COMMON_CFLAGS+=-Wall -pedantic -Wundef -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
+COMMON_CFLAGS+=-Wall -pedantic -Werror -Wundef -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 # not reliable enough: COMMON_CPPFLAGS+=-Wmissing-noreturn -ansi -pedantic -Wall -Werror -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
-COMMON_CPPFLAGS+=-ansi -pedantic -Wall -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
+COMMON_CPPFLAGS+=-ansi -pedantic -Wall -Werror -D SHARED_DIR=\"$(SHARED_DIR)\" -pthread
 COMMON_LDFLAGS+=-Wl,--fatal-warnings -pthread
 
 # Ubuntu 12.04 needs this for clock_gettime

--- a/src/core/include/MDist.tcc
+++ b/src/core/include/MDist.tcc
@@ -114,7 +114,7 @@ namespace MFM {
        obvious we can make this.
     */
     u32 eslIndex = 0;
-    s32 currentESL = -1;
+    u32 currentESL = -1;
     u32 firstESLIdx = 0;
     const s32 SR = (s32) R;
     for (u32 esl = 0; esl <= 2*R*R; ++esl) 

--- a/src/core/include/Parameter.h
+++ b/src/core/include/Parameter.h
@@ -244,9 +244,7 @@ namespace MFM
       if (this->GetType()==VD::U32)
       {
         this->m_vDesc.SetValueU32(atom, val);
-        return;
       }
-      return;
     }
 
     /////////
@@ -267,9 +265,7 @@ namespace MFM
       if (this->GetType()==VD::S32)
       {
         this->m_vDesc.SetValueS32(atom, val);
-        return;
       }
-      return;
     }
 
     /////////
@@ -290,9 +286,7 @@ namespace MFM
       if (this->GetType()==VD::BOOL)
       {
         this->m_vDesc.SetValueBool(atom, val);
-        return;
       }
-      return;
     }
 
     /////////
@@ -313,9 +307,7 @@ namespace MFM
       if (this->GetType()==VD::UNARY)
       {
         this->m_vDesc.SetValueUnary(atom, val);
-        return;
       }
-      return;
     }
 
     /**

--- a/src/core/include/Parameter.h
+++ b/src/core/include/Parameter.h
@@ -244,9 +244,9 @@ namespace MFM
       if (this->GetType()==VD::U32)
       {
         this->m_vDesc.SetValueU32(atom, val);
-        return true;
+        return;
       }
-      return false;
+      return;
     }
 
     /////////
@@ -267,9 +267,9 @@ namespace MFM
       if (this->GetType()==VD::S32)
       {
         this->m_vDesc.SetValueS32(atom, val);
-        return true;
+        return;
       }
-      return false;
+      return;
     }
 
     /////////
@@ -290,9 +290,9 @@ namespace MFM
       if (this->GetType()==VD::BOOL)
       {
         this->m_vDesc.SetValueBool(atom, val);
-        return true;
+        return;
       }
-      return false;
+      return;
     }
 
     /////////
@@ -313,9 +313,9 @@ namespace MFM
       if (this->GetType()==VD::UNARY)
       {
         this->m_vDesc.SetValueUnary(atom, val);
-        return true;
+        return;
       }
-      return false;
+      return;
     }
 
     /**

--- a/src/core/include/Tile.h
+++ b/src/core/include/Tile.h
@@ -414,17 +414,25 @@ namespace MFM
     }
 
     iterator_type begin(bool all) {
-      if (all) return beginAll(); return beginOwned();
+      if (all)
+          return beginAll();
+      return beginOwned();
     }
     const_iterator_type begin(bool all) const {
-      if (all) return beginAll(); return beginOwned();
+      if (all)
+          return beginAll();
+      return beginOwned();
     }
 
     iterator_type end(bool all) {
-      if (all) return endAll(); return endOwned();
+      if (all)
+          return endAll();
+      return endOwned();
     }
     const_iterator_type end(bool all) const {
-      if (all) return endAll(); return endOwned();
+      if (all)
+          return endAll();
+      return endOwned();
     }
 
   private:
@@ -756,7 +764,7 @@ namespace MFM
       m_ucr = heroTile.m_ucr;
 
       const UlamClass<EC> * uempty = m_ucr.GetUlamElementEmpty();
-      if (uempty) 
+      if (uempty)
       {
         const UlamElement<EC> * uelt = uempty->AsUlamElement();
         if (uelt)

--- a/src/elements/Makefile
+++ b/src/elements/Makefile
@@ -17,8 +17,8 @@ ELEMENTS:=$(wildcard src/Element_*.cpp)
 ELEMENT_HEADER_INCLUDES:=$(patsubst src/%.cpp,\#include "%.h"\n,$(ELEMENTS))
 #${warning EHI $(ELEMENT_HEADER_INCLUDES) iha}
 ELEMENT_MACRO_INVOKES:=$(patsubst src/%.cpp,XX(%);,$(ELEMENTS))
-UNUSED1:=${shell echo '$(ELEMENT_HEADER_INCLUDES)' > include/StdElementsHeaders.inc}
-UNUSED2:=${shell echo "$(ELEMENT_MACRO_INVOKES)" > include/StdElements.inc}
+UNUSED1:=${shell printf '$(ELEMENT_HEADER_INCLUDES)' > include/StdElementsHeaders.inc}
+UNUSED2:=${shell printf "$(ELEMENT_MACRO_INVOKES)" > include/StdElements.inc}
 
 # Do the library thing
 include $(BASEDIR)/config/Makelib.mk


### PR DESCRIPTION
Not sure if it interests you, but I recently built ULAM and MFM on Solus 1.2.1 64-bit, with GCC 6.1 and std=gnu++11, and managed to resolve some build problems I had. Note, I was having a lot of warnings, so I disabled Werror, and I just kind-of choose C++11 standard because I wasn't sure what your target standard was.

**Findings:**
- My distros echo command doesn't print \n characters, so I had to use the printf command
- Had some errors involving void returning functions returning bools, see src/core/include/Parameter.h
