### PR TITLE
Add parsable grid data output

### DIFF
--- a/src/sim/include/AbstractDriver.h
+++ b/src/sim/include/AbstractDriver.h
@@ -1225,7 +1225,7 @@ namespace MFM
       const u32 gridWidth = grid.GetWidthSites();
       const u32 gridHeight = grid.GetHeightSites();
       const bool isStaggeredGrid = grid.IsGridLayoutStaggered();
-
+      bool first = true;
       for(s32 y = 0; y < (s32)gridHeight; y++)
         {
 	  for(s32 x = 0; x < (s32)gridWidth; x++)
@@ -1255,13 +1255,23 @@ namespace MFM
             const UlamElement<EC> * uelt = e->AsUlamElement();
 
             uelt->Print(ucr, buff, *atom, printFlags, T::ATOM_FIRST_STATE_BIT);
+	    
+	    // ensure there isn't a trailing comma.
+	    if(!first)
+	    {
+	      fs.Printf(",\n");
+	    }
+	    else
+	    {
+              first = false;
+	    }
 
   	    fs.Printf("{\"x\":%d, " 
 		      "\"y\":%d, "
 		      "\"symbol\":\"%s\", "
 		      "\"name\":\"%s\", "
 		      "\"argb\":%d, "
-		      "\"data_string\":\"%s\"},\n"
+		      "\"data_string\":\"%s\"}"
 		      ,siteInGrid.GetX()
 		      ,siteInGrid.GetY()
 		      ,e->GetAtomicSymbol()
@@ -1270,7 +1280,7 @@ namespace MFM
 		      ,buff.GetZString());
   	  }
         }
-      fs.Printf("]");
+      fs.Printf("\n]");
       fs.Close();
     }
     

--- a/src/sim/include/AbstractDriver.h
+++ b/src/sim/include/AbstractDriver.h
@@ -476,6 +476,11 @@ namespace MFM
       }
 
       DefineNeededElements();
+      SaveElementMeta();
+      if (this->m_saveElementMeta)
+      {
+	SaveElementMeta();
+      }
     }
 
     /**
@@ -823,6 +828,11 @@ namespace MFM
       driver.m_includeCPPDemos = 1;
     }
 
+    static void SetSaveElementMeta(const char* not_needed, void* driver)
+    {
+      ((AbstractDriver*)driver)->m_saveElementMeta = 1;
+    }
+
     static void SetGridImages(const char* not_needed, void* driver)
     {
       ((AbstractDriver*)driver)->m_gridImages = 1;
@@ -1126,6 +1136,26 @@ namespace MFM
       SaveGrid(filename);
     }
 
+    void SaveElementMeta()
+    {
+      const char* filename =
+        GetSimDirPathTemporary("element.meta");
+      LOG.Message("Saving element meta to: %s", filename);
+      FILE* fp = fopen(filename, "w");
+      FileByteSink fs(fp);
+      fs.Printf("test bytesink");
+      
+      u32 dlcount = m_elementRegistry.GetRegisteredElementCount();
+      for (u32 i = 0; i < dlcount; ++i)
+      {
+        Element<EC> * e = m_elementRegistry.GetRegisteredElement(i);
+	fs.Printf(e->GetName());
+	fs.Printf(e->GetAtomicSymbol());
+      }
+
+      fs.Close();
+    }
+
     ExternalConfig<GC> & GetExternalConfig()
     {
       return m_externalConfig;
@@ -1258,6 +1288,7 @@ namespace MFM
       , m_suppressStdElements(true)
       , m_includeUEDemos(false)
       , m_includeCPPDemos(false)
+      , m_saveElementMeta(false)
       , m_msSpentRunning(0)
       , m_msSpentOverhead(0)
       , m_microsSleepPerFrame(1000)
@@ -1455,6 +1486,10 @@ namespace MFM
 
       RegisterArgument("Command line comment, logged but otherwise ignored (string)",
                        "-#|--comment", &IgnoreComment, this, true);
+      
+      RegisterArgument("Output element data member names and bit positions for parsing mfs save data.",
+                       "-sm|--save-meta", &SetSaveElementMeta, this, false);
+      
 
     }
 
@@ -1602,6 +1637,7 @@ namespace MFM
     bool m_suppressStdElements;
     bool m_includeUEDemos;
     bool m_includeCPPDemos;
+    bool m_saveElementMeta;
 
     u64 m_msSpentRunning;
     u64 m_msSpentOverhead;

--- a/src/sim/include/AbstractDriver.h
+++ b/src/sim/include/AbstractDriver.h
@@ -833,11 +833,6 @@ namespace MFM
       ((AbstractDriver*)driver)->m_saveGridDetail = 1;
     }
 
-    static void SetSaveBaseDetail(const char* not_needed, void* driver)
-    {
-      ((AbstractDriver*)driver)->m_saveBaseDetail = 1;
-    }
-
     static void SetGridImages(const char* not_needed, void* driver)
     {
       ((AbstractDriver*)driver)->m_gridImages = 1;
@@ -1141,20 +1136,11 @@ namespace MFM
       SaveGrid(filename);
     }
     
-    void AutosaveDetail(OurGrid& grid, u32 epochs, bool saveBase)
+    void AutosaveDetail(u32 epochs)
     {
-      if (saveBase)
-      {
-        const char* filename =
-          GetSimDirPathTemporary("base-%D-%D.save", epochs, (u32) m_AEPS);
-        this->SaveGridDetail(grid, filename, true);
-      }
-      else
-      {
-        const char* filename =
-          GetSimDirPathTemporary("grid-%D-%D.save", epochs, (u32) m_AEPS);
-        this->SaveGridDetail(grid, filename, true);
-      }
+      const char* filename =
+        GetSimDirPathTemporary("grid-%D-%D.save", epochs, (u32) m_AEPS);
+      this->SaveGridDetail(filename);
     }
     
 
@@ -1226,9 +1212,9 @@ namespace MFM
       fs.Close();
     }
     
-    void SaveGridDetail(OurGrid& grid, const char* filename, bool saveBaseState)
+    void SaveGridDetail(const char* filename)
     {
-
+      OurGrid& grid = this->GetGrid();
       LOG.Message("Saving detail to: %s", filename);
       FILE* fp = fopen(filename, "w");
       FileByteSink fs(fp);
@@ -1367,12 +1353,7 @@ namespace MFM
 
       if (m_saveGridDetail > 0 && (epochs % m_autosavePerEpochs) == 0)
       {
-	this->AutosaveDetail(grid, epochs, false);
-      }
-
-      if (m_saveBaseDetail > 0 && (epochs % m_autosavePerEpochs) == 0)
-      {
-	this->AutosaveDetail(grid, epochs, true);
+	this->AutosaveDetail(epochs);
       }
 
       if (m_accelerateAfterEpochs > 0 && (epochs % m_accelerateAfterEpochs) == 0)
@@ -1406,7 +1387,6 @@ namespace MFM
       , m_includeCPPDemos(false)
       , m_saveElementMeta(false)
       , m_saveGridDetail(false)
-      , m_saveBaseDetail(false)
       , m_msSpentRunning(0)
       , m_msSpentOverhead(0)
       , m_microsSleepPerFrame(1000)
@@ -1610,10 +1590,6 @@ namespace MFM
 
       RegisterArgument("Output detailed grid state information, including data member names for each site on the grid.",
                        "-gd|--grid-detail", &SetSaveGridDetail, this, false);
-
-      RegisterArgument("Output detailed information like grid-detail, but for the base layer.",
-                       "-bd|--base-detail", &SetSaveBaseDetail, this, false);
-
     }
 
 
@@ -1770,7 +1746,6 @@ namespace MFM
     bool m_includeCPPDemos;
     bool m_saveElementMeta;
     bool m_saveGridDetail;
-    bool m_saveBaseDetail;
 
     u64 m_msSpentRunning;
     u64 m_msSpentOverhead;


### PR DESCRIPTION
The purpose of this patch is to add an option to output the grid state in JSON format each epoch along with the .mfs save files. This output includes a string with data member names and values.
I've built a bit of tooling around this patch and I'm convinced it's a workable solution for easily analyzing logical (non/extra-spatial?) relationships between atoms and changes to systems of atoms within the MFM over time. 
There are some improvements which could be made to this feature.
First, it doesn't output base layer state, which would be nice to have.
Second, data member names and values are output as a non-JSON string which requires further parsing. I've made a python implementation of a parser to convert this into standard JSON: [mfm-griddata-parser](https://github.com/spencerharmon/mfm-griddata-parser) 
Third, very long strings representing data member names and values are truncated and some data is lost.