### PR TITLE
Fixed mfzrun script exiting because of a regex assuming english locale

### DIFF
--- a/src/drivers/mfzrun/mfzmake.tmpl
+++ b/src/drivers/mfzrun/mfzmake.tmpl
@@ -5,6 +5,7 @@ use strict;
 sub BEGIN {
     # Seal us up a bit for living la vida tainted
     $ENV{'PATH'} = "/bin:/usr/bin";
+    $ENV{'LC_ALL'} = "C";
     delete @ENV{'IFS', 'CDPATH', 'ENV', 'BASH_ENV'};
 }
 

--- a/src/drivers/mfzrun/mfzrun.tmpl
+++ b/src/drivers/mfzrun/mfzrun.tmpl
@@ -5,6 +5,7 @@ use strict;
 sub BEGIN {
     # Seal us up a bit for living la vida tainted
     $ENV{'PATH'} = "/bin:/usr/bin";
+    $ENV{'LC_ALL'} = "C";
     delete @ENV{'IFS', 'CDPATH', 'ENV', 'BASH_ENV'};
 }
 


### PR DESCRIPTION
The issue seems to appear in systems configured with locale other than English (default) for command-line programs.
A regex line 755 of `mfzrun` was assuming an English output for the `objdump` command and ultimately caused unnecessary program exit.

This PR should fix the issue by setting the locale to default in the Perl scripts (`mfzrun` and `mfzmake`).