### PR TITLE
use the more portable uname flag -m

### DIFF
--- a/src/drivers/mfzrun/mfzrun.tmpl
+++ b/src/drivers/mfzrun/mfzrun.tmpl
@@ -262,7 +262,7 @@ if ($verb eq "unpack") {
 my @mfmargs;
 
 my ($ulams,$splats,$incs,$goodSOs, $badSOs) = (0,0,0,0,0);
-my $platform = `/bin/uname -i`;
+my $platform = `/bin/uname -m`;
 chomp $platform;
 my $platformsize;
 if ($platform eq 'x86_64' || $platform =~ /^armv8.*/) {


### PR DESCRIPTION
I had issues on Arch Linux with running `mfzrun` as the software is unable to detect my CPU architecture using `uname -i`.
Changing it to `uname -m` fixed it and judging by [the table on wikipedia](https://en.wikipedia.org/wiki/Uname), `uname -m` is more reliable.