### PR TITLE
Fix: inverse symmetries

### DIFF
--- a/src/core/include/PSym.h
+++ b/src/core/include/PSym.h
@@ -112,7 +112,9 @@ namespace MFM {
      points mapped by psym to their original coordinates
    */
   inline const PointSymmetry SymInverse(const PointSymmetry psym) {
-    return (const PointSymmetry) (psym ^ ((psym & 1) << 1)); // PSYM_DEG090{L,R} <-> PSYM_DEG270{L,R}
+    return ((psym & 5) == 1)
+      ? (const PointSymmetry) (psym ^ 2) // PSYM_DEG090L <-> PSYM_DEG270L
+      : psym;
   }
 
 } /* namespace MFM */

--- a/src/test/include/PSym_Test.h
+++ b/src/test/include/PSym_Test.h
@@ -16,6 +16,7 @@ namespace MFM {
 
     static void Test_PSymTemplates();
 
+    static void Test_PSymInverse();
   };
 } /* namespace MFM */
 #endif /*PSYM_TEST_H*/

--- a/src/test/src/PSym_Test.cpp
+++ b/src/test/src/PSym_Test.cpp
@@ -7,6 +7,7 @@ namespace MFM {
   void PSym_Test::Test_RunTests() {
     Test_PSymTemplates();
     Test_PSymMap();
+    Test_PSymInverse();
   }
 
   void PSym_Test::Test_PSymTemplates()
@@ -69,7 +70,25 @@ namespace MFM {
     assert(SymMap(in,PSYM_FLIPX,err) == SymMap(in, PSYM_DEG180R,err2));
     assert(SymMap(in,PSYM_FLIPY,err) == SymMap(in, PSYM_DEG000R,err2));
     assert(SymMap(in,PSYM_FLIPXY,err)== SymMap(in, PSYM_DEG180L,err2));
+  }
 
+  void PSym_Test::Test_PSymInverse()
+  {
+    const unsigned num = 4;
+    const SPoint in[num] = {SPoint(-1, 0), SPoint(0, -1), SPoint(0, 1), SPoint(1, 0)};
+    const SPoint err(10, 10);
+
+    // Inverse of symmetry should return the original point
+    for (unsigned i = 0; i < num; i++) {
+      assert(SymMap(SymMap(in[i], PSYM_DEG000L, err), SymInverse(PSYM_DEG000L), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG090L, err), SymInverse(PSYM_DEG090L), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG180L, err), SymInverse(PSYM_DEG180L), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG270L, err), SymInverse(PSYM_DEG270L), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG000R, err), SymInverse(PSYM_DEG000R), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG090R, err), SymInverse(PSYM_DEG090R), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG180R, err), SymInverse(PSYM_DEG180R), err) == in[i]);
+      assert(SymMap(SymMap(in[i], PSYM_DEG270R, err), SymInverse(PSYM_DEG270R), err) == in[i]);
+    }
   }
 
 } /* namespace MFM */


### PR DESCRIPTION
All symmetries except 90L and 270L are equal to their inverse.

Currently `EventWindow.getSiteNumber(Atom&)` returns wrong sites  for `90R` and `270R`: [A.ulam.txt](https://github.com/DaveAckley/MFM/files/13325972/A.ulam.txt)


I don't know enough group theory, so I just mapped site numbers 1 to 4 under different symmetries and checked their inverses this way: [inverse.txt](https://github.com/DaveAckley/MFM/files/13325948/inverse.txt). Full multiplication table for the group:
```
(s1 * s2)(x) = s1(s2(x))
|---------+------+------+------+------+------+------+------+------|
| s1 \ s2 | 0L   | 90L  | 180L | 270L | 0R   | 90R  | 180R | 270R |
|---------+------+------+------+------+------+------+------+------|
| 0L      | 0L   | 90L  | 180L | 270L | 0R   | 90L  | 180R | 270R |
|---------+------+------+------+------+------+------+------+------|
| 90L     | 90L  | 180L | 270L | 0L   | 90R  | 180R | 270R | 0R   |
|---------+------+------+------+------+------+------+------+------|
| 180L    | 180L | 270L | 0L   | 90L  | 180R | 270R | 0R   | 90R  |
|---------+------+------+------+------+------+------+------+------|
| 270L    | 270L | 0L   | 90L  | 180L | 270R | 0R   | 90R  | 180R |
|---------+------+------+------+------+------+------+------+------|
| 0R      | 0R   | 270R | 180R | 90R  | 0L   | 270L | 180L | 90L  |
|---------+------+------+------+------+------+------+------+------|
| 90R     | 90R  | 0R   | 270R | 180R | 90L  | 0L   | 270L | 180L |
|---------+------+------+------+------+------+------+------+------|
| 180R    | 180R | 90R  | 0R   | 270R | 180L | 90L  | 0L   | 270L |
|---------+------+------+------+------+------+------+------+------|
| 270R    | 270R | 180R | 90R  | 0R   | 270L | 180L | 90L  | 0L   |
|---------+------+------+------+------+------+------+------+------|
```

Also, comment in [PSym.h](https://github.com/DaveAckley/MFM/blob/e1ee51c733eddbcb2f6b072c170383aa194d0ada/src/core/include/PSym.h#L35) doesn't match how the symmetries currently work, but I ignored it for now.